### PR TITLE
Remove salsa2012+gmac method

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -36,7 +36,7 @@
 	},
 
 	fastd_mesh_vpn = {
-		methods = {'salsa2012+umac', 'salsa2012+gmac'},
+		methods = {'salsa2012+umac'},
 		mtu = 1426,
 		backbone = {
 			limit = 2,


### PR DESCRIPTION
All our gateways support UMAC now, so we can drop GMAC support.
